### PR TITLE
add unordered option to mapping operations via new `ordered: bool` param (closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ assert list(integer_strings) == ['0', '-1', '-2', '-3', '-4', '-5', '-6', '-7', 
 ```
 
 ### thread-based concurrency
-> Applies the transformation concurrently using a thread pool of size `concurrency` (preserving the order):
+> Applies the transformation concurrently using a thread queue of size `concurrency`, and preserving the upstream order by default:
 ```python
 import requests
 
@@ -119,7 +119,7 @@ assert list(pokemon_names) == ['bulbasaur', 'ivysaur', 'venusaur']
 ```
 
 ### async-based concurrency
-> The sibling operation called `.amap` applies an async transformation (preserving the order):
+> The sibling operation `.amap` applies an async function:
 ```python
 import httpx
 import asyncio
@@ -152,7 +152,7 @@ assert list(self_printing_integers) == list(integers)  # triggers the printing
 > Like `.map` it has an optional `concurrency: int` parameter.
 
 ### async-based concurrency
-> Like `.map` it has a sibling operation `.aforeach` for async.
+> Like `.map` it has a sibling `.aforeach` operation for async.
 
 ## `.filter`
 > Keeps only the elements that satisfy a condition:

--- a/streamable/functions.py
+++ b/streamable/functions.py
@@ -102,7 +102,10 @@ def group(
 
 
 def map(
-    transformation: Callable[[T], U], iterator: Iterator[T], concurrency: int = 1
+    transformation: Callable[[T], U],
+    iterator: Iterator[T],
+    concurrency: int = 1,
+    ordered: bool = True,
 ) -> Iterator[U]:
     validate_iterator(iterator)
     validate_concurrency(concurrency)
@@ -117,6 +120,7 @@ def map(
                     transformation,
                     concurrency=concurrency,
                     buffer_size=concurrency,
+                    ordered=ordered,
                 )
             )
         )
@@ -126,6 +130,7 @@ def amap(
     transformation: Callable[[T], Coroutine[Any, Any, U]],
     iterator: Iterator[T],
     concurrency: int = 1,
+    ordered: bool = True,
 ) -> Iterator[U]:
     validate_iterator(iterator)
     validate_concurrency(concurrency)
@@ -135,6 +140,7 @@ def amap(
                 iterator,
                 transformation,
                 buffer_size=concurrency,
+                ordered=ordered,
             )
         )
     )

--- a/streamable/iters.py
+++ b/streamable/iters.py
@@ -1,8 +1,15 @@
+import asyncio
 import time
 from abc import ABC, abstractmethod
-from asyncio import AbstractEventLoop, Task, get_event_loop
+from asyncio import AbstractEventLoop, get_event_loop
 from collections import defaultdict, deque
-from concurrent.futures import Executor, Future, ThreadPoolExecutor
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Executor,
+    Future,
+    ThreadPoolExecutor,
+    wait,
+)
 from contextlib import contextmanager
 from datetime import datetime
 from math import ceil
@@ -343,9 +350,11 @@ class ConcurrentMappingIterable(
         self,
         iterator: Iterator[T],
         buffer_size: int,
+        ordered: bool,
     ) -> None:
         self.iterator = iterator
         self.buffer_size = buffer_size
+        self.ordered = ordered
 
     @abstractmethod
     def _context_manager(self) -> ContextManager: ...
@@ -354,9 +363,10 @@ class ConcurrentMappingIterable(
     def _launch_future(
         self, elem: T
     ) -> "Future[Union[U, RaisingIterator.ExceptionContainer]]": ...
+
     @abstractmethod
-    def _get_future_result(
-        self, future: "Future[Union[U, RaisingIterator.ExceptionContainer]]"
+    def _next_yield(
+        self, futures: "Deque[Future[Union[U, RaisingIterator.ExceptionContainer]]]"
     ) -> Union[U, RaisingIterator.ExceptionContainer]: ...
 
     def __iter__(self) -> Iterator[Union[U, RaisingIterator.ExceptionContainer]]:
@@ -370,7 +380,7 @@ class ConcurrentMappingIterable(
             # wait, queue, yield (FIFO)
             while True:
                 if futures:
-                    to_yield.append(self._get_future_result(futures.popleft()))
+                    to_yield.append(self._next_yield(futures))
                 # queue tasks up to buffer_size
                 while len(futures) < self.buffer_size:
                     try:
@@ -392,8 +402,9 @@ class ThreadConcurrentMappingIterable(ConcurrentMappingIterable[T, U]):
         transformation: Callable[[T], U],
         concurrency: int,
         buffer_size: int,
+        ordered: bool,
     ) -> None:
-        super().__init__(iterator, buffer_size)
+        super().__init__(iterator, buffer_size, ordered)
         self.transformation = transformation
         self.concurrency = concurrency
         self.executor: Executor
@@ -415,10 +426,16 @@ class ThreadConcurrentMappingIterable(ConcurrentMappingIterable[T, U]):
     ) -> "Future[Union[U, RaisingIterator.ExceptionContainer]]":
         return self.executor.submit(self._safe_transformation, elem)
 
-    def _get_future_result(
-        self, future: "Future[Union[U, RaisingIterator.ExceptionContainer]]"
+    def _next_yield(
+        self, futures: "Deque[Future[Union[U, RaisingIterator.ExceptionContainer]]]"
     ) -> Union[U, RaisingIterator.ExceptionContainer]:
-        return future.result()
+        if self.ordered:
+            return futures.popleft().result()
+        else:
+            done_futures, _ = wait(futures, return_when=FIRST_COMPLETED)
+            done_future = next(iter(done_futures))
+            futures.remove(done_future)
+            return done_future.result()
 
 
 class AsyncConcurrentMappingIterable(ConcurrentMappingIterable[T, U]):
@@ -427,8 +444,9 @@ class AsyncConcurrentMappingIterable(ConcurrentMappingIterable[T, U]):
         iterator: Iterator[T],
         transformation: Callable[[T], Coroutine[Any, Any, U]],
         buffer_size: int,
+        ordered: bool,
     ) -> None:
-        super().__init__(iterator, buffer_size)
+        super().__init__(iterator, buffer_size, ordered)
         self.transformation = transformation
         self.loop: AbstractEventLoop
 
@@ -458,12 +476,18 @@ class AsyncConcurrentMappingIterable(ConcurrentMappingIterable[T, U]):
             self.loop.create_task(self._safe_transformation(elem)),
         )
 
-    def _get_future_result(
-        self, future: "Future[Union[U, RaisingIterator.ExceptionContainer]]"
+    def _next_yield(
+        self, futures: "Deque[Future[Union[U, RaisingIterator.ExceptionContainer]]]"
     ) -> Union[U, RaisingIterator.ExceptionContainer]:
-        return self.loop.run_until_complete(
-            cast("Task[Union[U, RaisingIterator.ExceptionContainer]]", future)
-        )
+        if self.ordered:
+            return self.loop.run_until_complete(futures.popleft())  # type: ignore
+        else:
+            done_futures, _ = self.loop.run_until_complete(
+                asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)  # type: ignore
+            )
+            done_future = next(iter(done_futures))
+            futures.remove(done_future)
+            return done_future.result()
 
 
 class ConcurrentFlatteningIterable(

--- a/streamable/iters.py
+++ b/streamable/iters.py
@@ -364,7 +364,9 @@ class ConcurrentMappingIterable(
             futures: Deque["Future[Union[U, RaisingIterator.ExceptionContainer]]"] = (
                 deque()
             )
-            to_yield: List[Union[U, RaisingIterator.ExceptionContainer]] = []
+            to_yield: Deque[Union[U, RaisingIterator.ExceptionContainer]] = deque(
+                maxlen=1
+            )
             # wait, queue, yield (FIFO)
             while True:
                 if futures:
@@ -480,8 +482,10 @@ class ConcurrentFlatteningIterable(
     def __iter__(self) -> Iterator[Union[T, RaisingIterator.ExceptionContainer]]:
         with ThreadPoolExecutor(max_workers=self.concurrency) as executor:
             iterator_and_future_pairs: Deque[Tuple[Iterator[T], Future]] = deque()
-            element_to_yield: List[Union[T, RaisingIterator.ExceptionContainer]] = []
-            iterator_to_queue: List[Iterator[T]] = []
+            element_to_yield: Deque[Union[T, RaisingIterator.ExceptionContainer]] = (
+                deque(maxlen=1)
+            )
+            iterator_to_queue: Deque[Iterator[T]] = deque(maxlen=1)
             # wait, queue, yield (FIFO)
             while True:
                 if iterator_and_future_pairs:

--- a/streamable/visitors/iterator.py
+++ b/streamable/visitors/iterator.py
@@ -49,6 +49,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
                 stream.upstream,
                 util.sidify(stream._effect),
                 stream._concurrency,
+                stream._ordered,
             )
         )
 
@@ -58,6 +59,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
                 stream.upstream,
                 util.async_sidify(stream._effect),
                 stream._concurrency,
+                stream._ordered,
             )
         )
 
@@ -77,6 +79,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
             stream._transformation,
             stream.upstream.accept(IteratorVisitor[U]()),
             concurrency=stream._concurrency,
+            ordered=stream._ordered,
         )
 
     def visit_amap_stream(self, stream: AMapStream[U, T]) -> Iterator[T]:
@@ -84,6 +87,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
             stream._transformation,
             stream.upstream.accept(IteratorVisitor[U]()),
             concurrency=stream._concurrency,
+            ordered=stream._ordered,
         )
 
     def visit_observe_stream(self, stream: ObserveStream[T]) -> Iterator[T]:

--- a/streamable/visitors/representation.py
+++ b/streamable/visitors/representation.py
@@ -51,13 +51,13 @@ class RepresentationVisitor(Visitor[str]):
 
     def visit_foreach_stream(self, stream: ForeachStream[T]) -> str:
         self.methods_reprs.append(
-            f"foreach({self._friendly_repr(stream._effect)}, concurrency={stream._concurrency})"
+            f"foreach({self._friendly_repr(stream._effect)}, concurrency={stream._concurrency}, ordered={stream._ordered})"
         )
         return stream.upstream.accept(self)
 
     def visit_aforeach_stream(self, stream: AForeachStream[T]) -> str:
         self.methods_reprs.append(
-            f"aforeach({self._friendly_repr(stream._effect)}, concurrency={stream._concurrency})"
+            f"aforeach({self._friendly_repr(stream._effect)}, concurrency={stream._concurrency}, ordered={stream._ordered})"
         )
         return stream.upstream.accept(self)
 
@@ -69,13 +69,13 @@ class RepresentationVisitor(Visitor[str]):
 
     def visit_map_stream(self, stream: MapStream[U, T]) -> str:
         self.methods_reprs.append(
-            f"map({self._friendly_repr(stream._transformation)}, concurrency={stream._concurrency})"
+            f"map({self._friendly_repr(stream._transformation)}, concurrency={stream._concurrency}, ordered={stream._ordered})"
         )
         return stream.upstream.accept(self)
 
     def visit_amap_stream(self, stream: AMapStream[U, T]) -> str:
         self.methods_reprs.append(
-            f"amap({self._friendly_repr(stream._transformation)}, concurrency={stream._concurrency})"
+            f"amap({self._friendly_repr(stream._transformation)}, concurrency={stream._concurrency}, ordered={stream._ordered})"
         )
         return stream.upstream.accept(self)
 


### PR DESCRIPTION
With @erezsh (issue #18).

Add optional unordering for faster concurrent `.map`/`.amap`/`.foreach`/`.aforeach` in case of heterogeneously expensive func calls.