### PR TITLE
add `running`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ zeros: Stream[int] = (
 assert list(zeros) == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 ```
 
+### "running map"
+
+> {TODO: add description}
+
+```python
+from streamable import running
+
+cumulative_sum: Stream[int] = (
+    integers
+    .map(running(lambda cumsum, i: cumsum + i, initial=0))
+)
+
+assert list(cumulative_sum) == [0, 1, 3, 6, 10, 15, 21, 28, 36, 45]
+```
+
 
 
 ## `.foreach`

--- a/streamable/__init__.py
+++ b/streamable/__init__.py
@@ -1,3 +1,2 @@
 from streamable.stream import Stream
-from streamable.util.functiontools import star
-from streamable.util.functiontools import running
+from streamable.util.functiontools import running, star

--- a/streamable/__init__.py
+++ b/streamable/__init__.py
@@ -1,2 +1,3 @@
 from streamable.stream import Stream
 from streamable.util.functiontools import star
+from streamable.util.functiontools import running

--- a/streamable/util/functiontools.py
+++ b/streamable/util/functiontools.py
@@ -114,3 +114,16 @@ def star(func: Callable[..., R]) -> Callable[[Tuple], R]:
     ```
     """
     return _Star(func)
+
+
+def running(func: Callable[[R, T], R], initial: R) -> Callable[[T], R]:
+    """
+    TODO
+    """
+    acc = initial
+    def _(elem: T) -> R:
+        nonlocal acc
+        acc = func(acc, elem)
+        return acc
+    return _
+

--- a/streamable/util/functiontools.py
+++ b/streamable/util/functiontools.py
@@ -121,9 +121,10 @@ def running(func: Callable[[R, T], R], initial: R) -> Callable[[T], R]:
     TODO
     """
     acc = initial
+
     def _(elem: T) -> R:
         nonlocal acc
         acc = func(acc, elem)
         return acc
-    return _
 
+    return _

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -89,6 +89,16 @@ class TestReadme(unittest.TestCase):
 
         assert list(zeros) == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
+    def test_running_map_example(self) -> None:
+        from streamable import running
+
+        cumulative_sum: Stream[int] = (
+            integers
+            .map(running(lambda cumsum, i: cumsum + i, initial=0))
+        )
+
+        assert list(cumulative_sum) == [0, 1, 3, 6, 10, 15, 21, 28, 36, 45]
+
     def test_foreach_example(self) -> None:
         state: List[int] = []
         appending_integers: Stream[int] = integers.foreach(state.append)


### PR DESCRIPTION
Adds the behavior of `itertools.accumulate` (aka `.scan` in Scala/Haskell).

### Examples
```python
from streamable import running

cumulative_sum = (
    Stream(range(10))
    .map(running(lambda cumsum, i: cumsum + i, initial=0))
)

assert list(cumulative_sum) == [0, 1, 3, 6, 10, 15, 21, 28, 36, 45]

fibonacci = (
    Stream(range(10))
    .map(running(lambda acc, _: (acc[1], acc[0] + acc[1]), initial=(0, 1)))
    .map(itemgetter(0))
)

assert list(fibonacci) == [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
```