### PR TITLE
1.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ assert list(integers_by_parity) == [("even", [0, 2, 4, 6, 8]), ("odd", [1, 3, 5,
 ```
 
 > [!TIP]
-> Then *"star map"* over the tuples:
+> Then *"starmap"* over the tuples:
 
 ```python
 from streamable import star
@@ -386,7 +386,7 @@ five_first_integers: Stream[int] = integers.truncate(5)
 assert list(five_first_integers) == [0, 1, 2, 3, 4]
 ```
 
-> ... or when a condition has become satisfied:
+> or `when` a condition is satisfied:
 
 ```python
 five_first_integers: Stream[int] = integers.truncate(when=lambda n: n == 5)
@@ -420,7 +420,7 @@ distinct_chars: Stream[str] = Stream("foobarfooo").distinct()
 assert list(distinct_chars) == ["f", "o", "b", "a", "r"]
 ```
 
-> Specify a function to deduplicate based on the value it returns when applied to elements:
+> specifying a deduplication `key`:
 
 ```python
 strings_of_distinct_lengths: Stream[str] = (

--- a/streamable/functions.py
+++ b/streamable/functions.py
@@ -72,13 +72,13 @@ def catch(
 
 def distinct(
     iterator: Iterator[T],
-    by: Optional[Callable[[T], Any]] = None,
+    key: Optional[Callable[[T], Any]] = None,
     consecutive_only: bool = False,
 ) -> Iterator[T]:
     validate_iterator(iterator)
     if consecutive_only:
-        return ConsecutiveDistinctIterator(iterator, by)
-    return DistinctIterator(iterator, by)
+        return ConsecutiveDistinctIterator(iterator, key)
+    return DistinctIterator(iterator, key)
 
 
 def flatten(iterator: Iterator[Iterable[T]], concurrency: int = 1) -> Iterator[T]:
@@ -110,14 +110,14 @@ def group(
 
 def groupby(
     iterator: Iterator[T],
-    by: Callable[[T], U],
+    key: Callable[[T], U],
     size: Optional[int] = None,
     interval: Optional[datetime.timedelta] = None,
 ) -> Iterator[Tuple[U, List[T]]]:
     validate_iterator(iterator)
     validate_group_size(size)
     validate_group_interval(interval)
-    return GroupbyIterator(iterator, by, size, interval)
+    return GroupbyIterator(iterator, key, size, interval)
 
 
 def map(

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -165,7 +165,7 @@ class Stream(Iterable[T]):
 
     def distinct(
         self, key: Optional[Callable[[T], Any]] = None, consecutive_only: bool = False
-    ) -> "Stream":
+    ) -> "Stream[T]":
         """
         Filters the stream to yield only distinct elements.
         If a deduplication `key` is specified, `foo` and `bar` are treated as duplicates when `key(foo) == key(bar)`.
@@ -429,7 +429,7 @@ class Stream(Iterable[T]):
         """
         return ObserveStream(self, what)
 
-    def skip(self, count: int) -> "Stream":
+    def skip(self, count: int) -> "Stream[T]":
         """
         Skips the first `count` elements.
 

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -120,10 +120,10 @@ class Stream(Iterable[T]):
         Catches the upstream exceptions if they are instances of `kind` and they satisfy the `when` predicate.
 
         Args:
-            kind (Type[Exception], optional): The type of exceptions to catch. (by default: catches base Exception)
-            when (Callable[[Exception], Any], optional): An additional condition that must be satisfied to catch the exception, i.e. `when(exception)` must be truthy. (by default: no additional condition)
-            replacement (T, optional): The value to yield when an exception is catched. (by default: do not yield any replacement value)
-            finally_raise (bool, optional): If True the first catched exception is raised when upstream's iteration ends. (by default: iteration ends without raising)
+            kind (Type[Exception], optional): The type of exceptions to catch. (default: catches base Exception)
+            when (Callable[[Exception], Any], optional): An additional condition that must be satisfied to catch the exception, i.e. `when(exception)` must be truthy. (default: no additional condition)
+            replacement (T, optional): The value to yield when an exception is catched. (default: do not yield any replacement value)
+            finally_raise (bool, optional): If True the first catched exception is raised when upstream's iteration ends. (default: iteration ends without raising)
 
         Returns:
             Stream[T]: A stream of upstream elements catching the eligible exceptions.
@@ -155,7 +155,7 @@ class Stream(Iterable[T]):
         Logs (INFO level) a representation of the stream.
 
         Args:
-            level (int, optional): The level of the log. (by default: INFO)
+            level (int, optional): The level of the log. (default: INFO)
 
         Returns:
             Stream[T]: This stream.
@@ -178,8 +178,8 @@ class Stream(Iterable[T]):
             Alternatively, remove only consecutive duplicates without memory footprint by setting `consecutive_only=True`.
 
         Args:
-            key (Callable[[T], Any], optional): Elements are deduplicated based on `key(elem)`. (by default: the deduplication is performed on the elements themselves)
-            consecutive_only (bool, optional): Whether to deduplicate only consecutive duplicates, or globally. (by default: the deduplication is global)
+            key (Callable[[T], Any], optional): Elements are deduplicated based on `key(elem)`. (default: the deduplication is performed on the elements themselves)
+            consecutive_only (bool, optional): Whether to deduplicate only consecutive duplicates, or globally. (default: the deduplication is global)
 
         Returns:
             Stream: A stream containing only unique upstream elements.
@@ -191,7 +191,7 @@ class Stream(Iterable[T]):
         Filters the stream to yield only elements satisfying the `when` predicate.
 
         Args:
-            when (Callable[[T], Any], optional): An element is kept when `when(elem)` is truthy. (by default: keeps all truthy elements)
+            when (Callable[[T], Any], optional): An element is kept when `when(elem)` is truthy. (default: keeps all truthy elements)
 
         Returns:
             Stream[T]: A stream of upstream elements satisfying the `when` predicate.
@@ -268,7 +268,7 @@ class Stream(Iterable[T]):
         Iterates over upstream elements assumed to be iterables, and individually yields their items.
 
         Args:
-            concurrency (int, optional): Represents both the number of threads used to concurrently flatten the upstream iterables and the number of iterables buffered. (by default: no concurrency)
+            concurrency (int, optional): Represents both the number of threads used to concurrently flatten the upstream iterables and the number of iterables buffered. (default: no concurrency)
         Returns:
             Stream[R]: A stream of flattened elements from upstream iterables.
         """
@@ -288,9 +288,9 @@ class Stream(Iterable[T]):
 
         Args:
             effect (Callable[[T], Any]): The function to be applied to each element as a side effect.
-            concurrency (int, optional): Represents both the number of threads used to concurrently apply the `effect` and the size of the buffer containing not-yet-yielded elements. If the buffer is full, the iteration over the upstream is paused until an element is yielded from the buffer. (by default: no concurrency)
-            ordered (bool, optional): If `concurrency` > 1, whether to preserve the order of upstream elements or to yield them as soon as they are processed. (by default: preserves upstream order)
-            via ("thread" or "process", optional): If `concurrency` > 1, whether to apply `transformation` using processes or threads. (by default: via threads)
+            concurrency (int, optional): Represents both the number of threads used to concurrently apply the `effect` and the size of the buffer containing not-yet-yielded elements. If the buffer is full, the iteration over the upstream is paused until an element is yielded from the buffer. (default: no concurrency)
+            ordered (bool, optional): If `concurrency` > 1, whether to preserve the order of upstream elements or to yield them as soon as they are processed. (default: preserves upstream order)
+            via ("thread" or "process", optional): If `concurrency` > 1, whether to apply `transformation` using processes or threads. (default: via threads)
         Returns:
             Stream[T]: A stream of upstream elements, unchanged.
         """
@@ -310,8 +310,8 @@ class Stream(Iterable[T]):
 
         Args:
             effect (Callable[[T], Any]): The asynchronous function to be applied to each element as a side effect.
-            concurrency (int, optional): Represents both the number of async tasks concurrently applying the `effect` and the size of the buffer containing not-yet-yielded elements. If the buffer is full, the iteration over the upstream is paused until an element is yielded from the buffer. (by default: no concurrency)
-            ordered (bool, optional): If `concurrency` > 1, whether to preserve the order of upstream elements or to yield them as soon as they are processed. (by default: preserves upstream order)
+            concurrency (int, optional): Represents both the number of async tasks concurrently applying the `effect` and the size of the buffer containing not-yet-yielded elements. If the buffer is full, the iteration over the upstream is paused until an element is yielded from the buffer. (default: no concurrency)
+            ordered (bool, optional): If `concurrency` > 1, whether to preserve the order of upstream elements or to yield them as soon as they are processed. (default: preserves upstream order)
         Returns:
             Stream[T]: A stream of upstream elements, unchanged.
         """
@@ -335,9 +335,9 @@ class Stream(Iterable[T]):
         If `by` is specified, groups will only contain elements sharing the same `by(elem)` value (see `.groupby` for `(key, elements)` pairs).
 
         Args:
-            size (Optional[int], optional): The maximum number of elements per group (default: no size limit).
-            interval (float, optional): Yields a group if `interval` seconds have passed since the last group was yielded. (by default: no limit on the time interval between yields)
-            by (Optional[Callable[[T], Any]], optional): If specified, groups will only contain elements sharing the same `by(elem)` value. (Default: does not co-group elements.)
+            size (Optional[int], optional): The maximum number of elements per group. (default: no size limit)
+            interval (float, optional): Yields a group if `interval` seconds have passed since the last group was yielded. (default: no interval limit)
+            by (Optional[Callable[[T], Any]], optional): If specified, groups will only contain elements sharing the same `by(elem)` value. (default: does not co-group elements)
         Returns:
             Stream[List[T]]: A stream of upstream elements grouped into lists.
         """
@@ -361,8 +361,8 @@ class Stream(Iterable[T]):
 
         Args:
             key (Callable[[T], U]): A function that returns the group key for an element.
-            size (Optional[int], optional): The maximum number of elements per group (default: no size limit).
-            interval (Optional[datetime.timedelta], optional): If specified, yields a group if `interval` seconds have passed since the last group was yielded (default: no time interval limit).
+            size (Optional[int], optional): The maximum number of elements per group. (default: no size limit)
+            interval (Optional[datetime.timedelta], optional): If specified, yields a group if `interval` seconds have passed since the last group was yielded. (default: no interval limit)
 
         Returns:
             Stream[Tuple[U, List[T]]]: A stream of upstream elements grouped by key, as `(key, elements)` tuples.
@@ -381,9 +381,9 @@ class Stream(Iterable[T]):
 
         Args:
             transformation (Callable[[T], R]): The function to be applied to each element.
-            concurrency (int, optional): Represents both the number of threads used to concurrently apply `transformation` and the size of the buffer containing not-yet-yielded results. If the buffer is full, the iteration over the upstream is paused until a result is yielded from the buffer. (by default: no concurrency)
-            ordered (bool, optional): If `concurrency` > 1, whether to preserve the order of upstream elements or to yield them as soon as they are processed. (by default: preserves upstream order)
-            via ("thread" or "process", optional): If `concurrency` > 1, whether to apply `transformation` using processes or threads. (by default: via threads)
+            concurrency (int, optional): Represents both the number of threads used to concurrently apply `transformation` and the size of the buffer containing not-yet-yielded results. If the buffer is full, the iteration over the upstream is paused until a result is yielded from the buffer. (default: no concurrency)
+            ordered (bool, optional): If `concurrency` > 1, whether to preserve the order of upstream elements or to yield them as soon as they are processed. (default: preserves upstream order)
+            via ("thread" or "process", optional): If `concurrency` > 1, whether to apply `transformation` using processes or threads. (default: via threads)
         Returns:
             Stream[R]: A stream of transformed elements.
         """
@@ -402,8 +402,8 @@ class Stream(Iterable[T]):
 
         Args:
             transformation (Callable[[T], Coroutine[Any, Any, U]]): The asynchronous function to be applied to each element.
-            concurrency (int, optional): Represents both the number of async tasks concurrently applying `transformation` and the size of the buffer containing not-yet-yielded results. If the buffer is full, the iteration over the upstream is paused until a result is yielded from the buffer. (by default: no concurrency)
-            ordered (bool, optional): If `concurrency` > 1, whether to preserve the order of upstream elements or to yield them as soon as they are processed. (by default: preserves upstream order)
+            concurrency (int, optional): Represents both the number of async tasks concurrently applying `transformation` and the size of the buffer containing not-yet-yielded results. If the buffer is full, the iteration over the upstream is paused until a result is yielded from the buffer. (default: no concurrency)
+            ordered (bool, optional): If `concurrency` > 1, whether to preserve the order of upstream elements or to yield them as soon as they are processed. (default: preserves upstream order)
         Returns:
             Stream[R]: A stream of transformed elements.
         """
@@ -436,8 +436,8 @@ class Stream(Iterable[T]):
         Skips the first `count` elements, or skips `until` a predicate becomes satisfied.
 
         Args:
-            count (Optional[int], optional): The number of elements to skip. (by default: no count-based skipping)
-            until (Optional[Callable[[T], Any]], optional): Elements are skipped until the first one for which `until(elem)` is truthy. This element and all the subsequent ones will be yielded. (by default: no predicate-based skipping)
+            count (Optional[int], optional): The number of elements to skip. (default: no count-based skipping)
+            until (Optional[Callable[[T], Any]], optional): Elements are skipped until the first one for which `until(elem)` is truthy. This element and all the subsequent ones will be yielded. (default: no predicate-based skipping)
 
         Returns:
             Stream: A stream of the upstream elements remaining after skipping.
@@ -462,10 +462,10 @@ class Stream(Iterable[T]):
         The upstream exceptions are slowed too.
 
         Args:
-            per_second (float, optional): Maximum number of yields per second. (by default: no limit per second)
-            per_minute (float, optional): Maximum number of yields per minute. (by default: no limit per minute)
-            per_hour (float, optional): Maximum number of yields per hour. (by default: no limit per hour)
-            interval (datetime.timedelta, optional): Minimum interval between yields. (by default: no interval constraint)
+            per_second (float, optional): Maximum number of yields per second. (default: no limit per second)
+            per_minute (float, optional): Maximum number of yields per minute. (default: no limit per minute)
+            per_hour (float, optional): Maximum number of yields per hour. (default: no limit per hour)
+            interval (datetime.timedelta, optional): Minimum interval between yields. (default: no interval constraint)
 
         Returns:
             Stream[T]: A stream yielding upstream elements according to the specified rate constraints.
@@ -483,8 +483,8 @@ class Stream(Iterable[T]):
         Stops an iteration as soon as the `when` predicate is satisfied or `count` elements have been yielded.
 
         Args:
-            count (int, optional): The maximum number of elements to yield. (by default: no count-based truncation)
-            when (Optional[Callable[[T], Any]], optional): A predicate function that determines when to stop the iteration. Iteration stops immediately after encountering the first element for which `when(elem)` is truthy, and that element will not be yielded. (by default: no predicate-based truncation)
+            count (int, optional): The maximum number of elements to yield. (default: no count-based truncation)
+            when (Optional[Callable[[T], Any]], optional): A predicate function that determines when to stop the iteration. Iteration stops immediately after encountering the first element for which `when(elem)` is truthy, and that element will not be yielded. (default: no predicate-based truncation)
 
         Returns:
             Stream[T]: A stream of at most `count` upstream elements not satisfying the `when` predicate.

--- a/streamable/util/validationtools.py
+++ b/streamable/util/validationtools.py
@@ -65,3 +65,15 @@ def validate_truncate_args(
             raise ValueError("`count` and `when` cannot both be None")
     else:
         validate_count(count)
+
+
+def validate_skip_args(
+    count: Optional[int] = None, until: Optional[Callable[[T], Any]] = None
+) -> None:
+    if count is None:
+        if until is None:
+            raise ValueError("`count` and `until` cannot both be None")
+    else:
+        if until is not None:
+            raise ValueError("`count` and `until` cannot both be set")
+        validate_count(count)

--- a/streamable/visitors/iterator.py
+++ b/streamable/visitors/iterator.py
@@ -124,6 +124,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
         return functions.skip(
             stream.upstream.accept(self),
             stream._count,
+            stream._until,
         )
 
     def visit_throttle_stream(self, stream: ThrottleStream[T]) -> Iterator[T]:

--- a/streamable/visitors/iterator.py
+++ b/streamable/visitors/iterator.py
@@ -38,7 +38,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
     def visit_distinct_stream(self, stream: DistinctStream[T]) -> Iterator[T]:
         return functions.distinct(
             stream.upstream.accept(self),
-            stream._by,
+            stream._key,
             stream._consecutive_only,
         )
 
@@ -91,7 +91,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
             Iterator[T],
             functions.groupby(
                 stream.upstream.accept(IteratorVisitor[U]()),
-                stream._by,
+                stream._key,
                 stream._size,
                 stream._interval,
             ),

--- a/streamable/visitors/representation.py
+++ b/streamable/visitors/representation.py
@@ -104,7 +104,9 @@ class ToStringVisitor(Visitor[str], ABC):
         return stream.upstream.accept(self)
 
     def visit_skip_stream(self, stream: SkipStream[T]) -> str:
-        self.methods_reprs.append(f"skip({self.to_string(stream._count)})")
+        self.methods_reprs.append(
+            f"skip({self.to_string(stream._count)}, until={self.to_string(stream._until)})"
+        )
         return stream.upstream.accept(self)
 
     def visit_throttle_stream(self, stream: ThrottleStream[T]) -> str:

--- a/streamable/visitors/representation.py
+++ b/streamable/visitors/representation.py
@@ -47,7 +47,7 @@ class ToStringVisitor(Visitor[str], ABC):
 
     def visit_distinct_stream(self, stream: DistinctStream[T]) -> str:
         self.methods_reprs.append(
-            f"distinct({self.to_string(stream._by)}, consecutive_only={self.to_string(stream._consecutive_only)})"
+            f"distinct({self.to_string(stream._key)}, consecutive_only={self.to_string(stream._consecutive_only)})"
         )
         return stream.upstream.accept(self)
 
@@ -82,7 +82,7 @@ class ToStringVisitor(Visitor[str], ABC):
 
     def visit_groupby_stream(self, stream: GroupbyStream[U, T]) -> str:
         self.methods_reprs.append(
-            f"groupby({self.to_string(stream._by)}, size={self.to_string(stream._size)}, interval={self.to_string(stream._interval)})"
+            f"groupby({self.to_string(stream._key)}, size={self.to_string(stream._size)}, interval={self.to_string(stream._interval)})"
         )
         return stream.upstream.accept(self)
 

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 # to show the CHANGELOG: git log -- version.py
-__version__ = "1.4.5"
+__version__ = "1.4.6"


### PR DESCRIPTION
TODO:
- [x] uniformize punctuation and `default:` in docstrings
- [x] move version update as last commit and update message with `until` introduction in `.skip`