### PR TITLE
Add a .pipe method

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ parameterized==0.9.0
 coverage==7.4.1
 httpx==0.28.1
 requests==2.32.3
+typing-extensions==4.12.2

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import sys
 from contextlib import suppress
 from typing import (
     TYPE_CHECKING,
@@ -42,9 +43,15 @@ if TYPE_CHECKING: import builtins
 if TYPE_CHECKING: from streamable.visitors import Visitor
 # fmt: on
 
+if sys.version_info >= (3, 10):
+    from typing import Concatenate, ParamSpec
+else:
+    from typing_extensions import Concatenate, ParamSpec
+
 U = TypeVar("U")
 T = TypeVar("T")
 V = TypeVar("V")
+P = ParamSpec("P")
 
 
 class Stream(Iterable[T]):
@@ -492,6 +499,14 @@ class Stream(Iterable[T]):
         """
         validate_optional_count(count)
         return TruncateStream(self, count, when)
+
+    def pipe(
+        self,
+        func: Callable[Concatenate["Stream[T]", P], V],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> V:
+        return func(self, *args, **kwargs)
 
 
 class DownStream(Stream[U], Generic[T, U]):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1577,3 +1577,20 @@ class TestStream(unittest.TestCase):
             msg="`aforeach` should raise a TypeError if a non async function is passed to it.",
         ):
             next(iter(stream))
+
+    def test_pipe(self) -> None:
+        def multi_arg_func(stream: Iterable[T], first: int, *, second: int) -> int:
+            return first + second
+
+        stream = Stream(src)
+        self.assertListEqual(
+            list(stream),
+            stream.pipe(list),
+            msg="The pipe method should forward the stream to the function it accepts.",
+        )
+
+        self.assertEqual(
+            multi_arg_func(stream, 1, second=2),
+            stream.pipe(multi_arg_func, 1, second=2),
+            msg="The pipe method should pass on both args and kwargs correctly.",
+        )


### PR DESCRIPTION
Implements a `.pipe` method (as suggested in #64) for passing the `Stream` as the first argument to any arbitrary `func`, with additional support for `*args` and `**kwargs`.

@ebonnal I'm not the most familiar with setting the type annotations correctly. I mostly just copied the implementation from Polars' `.pipe` method, but please let me know if something's not working as expected.

I can also add some docstrings and examples once you've verified the code itself works as expected.