### PR TITLE
1.5.0: kw-only args constraints; `.filter`/`.catch`: mandatory nullable first arg; `.throttle`: flexible params; (closes #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ from datetime import timedelta
 
 integers_within_1_sec: Stream[List[int]] = (
     integers
-    .throttle(per_second=2)
+    .throttle(2, per=timedelta(seconds=1))
     .group(interval=timedelta(seconds=0.99))
 )
 
@@ -423,27 +423,15 @@ assert len(errors) == len("foo")
 
 ## `.throttle`
 
-> Limits the number of yields `per_second`/`per_minute`/`per_hour`:
-
-```python
-integers_5_per_sec: Stream[int] = integers.throttle(per_second=3)
-
-# takes 3s: ceil(10 integers / 3 per_second) - 1
-assert list(integers_5_per_sec) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-```
-
-> and/or ensures a minimum `interval` between two successive yields:
+> Limits the number of yields `per` time interval:
 
 ```python
 from datetime import timedelta
 
-integers_every_100_millis = (
-    integers
-    .throttle(interval=timedelta(milliseconds=100))
-)
+three_integers_per_second: Stream[int] = integers.throttle(3, per=timedelta(seconds=1))
 
-# takes 900 millis: (10 integers - 1) * 100 millis
-assert list(integers_every_100_millis) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+# takes 3s: ceil(10 integers / 3 per_second) - 1
+assert list(three_integers_per_second) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 ```
 
 
@@ -451,7 +439,7 @@ assert list(integers_every_100_millis) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 > Logs the progress of iterations:
 ```python
->>> assert list(integers.throttle(per_second=2).observe("integers")) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+>>> assert list(integers.throttle(2, per=timedelta(seconds=1)).observe("integers")) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 ```
 ```
 INFO: [duration=0:00:00.001793 errors=0] 1 integers yielded
@@ -562,7 +550,7 @@ with open("./quadruped_pokemons.csv", mode="w") as file:
         # Infinite Stream[int] of Pokemon ids starting from Pokémon #1: Bulbasaur
         Stream(itertools.count(1))
         # Limits to 16 requests per second to be friendly to our fellow PokéAPI devs
-        .throttle(per_second=16)
+        .throttle(16, per=timedelta(seconds=1))
         # GETs pokemons concurrently using a pool of 8 threads
         .map(lambda poke_id: f"https://pokeapi.co/api/v2/pokemon-species/{poke_id}")
         .map(requests.get, concurrency=8)

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ with open("./quadruped_pokemons.csv", mode="w") as file:
         .flatten()
         .observe("written pokemons")
         # Catches exceptions and raises the 1st one at the end of the iteration
-        .catch(finally_raise=True)
+        .catch(Exception, finally_raise=True)
     )
 
     pipeline()

--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ class DepthVisitor(Visitor[int]):
 def depth(stream: Stream) -> int:
     return stream.accept(DepthVisitor())
 
-assert depth(Stream(range(10)).map(str).filter()) == 3
+assert depth(Stream(range(10)).map(str).foreach(print)) == 3
 ```
 
 ## Functions

--- a/streamable/functions.py
+++ b/streamable/functions.py
@@ -73,6 +73,7 @@ def catch(
 def distinct(
     iterator: Iterator[T],
     key: Optional[Callable[[T], Any]] = None,
+    *,
     consecutive_only: bool = False,
 ) -> Iterator[T]:
     validate_iterator(iterator)
@@ -81,7 +82,7 @@ def distinct(
     return DistinctIterator(iterator, key)
 
 
-def flatten(iterator: Iterator[Iterable[T]], concurrency: int = 1) -> Iterator[T]:
+def flatten(iterator: Iterator[Iterable[T]], *, concurrency: int = 1) -> Iterator[T]:
     validate_iterator(iterator)
     validate_concurrency(concurrency)
     if concurrency == 1:
@@ -97,6 +98,7 @@ def flatten(iterator: Iterator[Iterable[T]], concurrency: int = 1) -> Iterator[T
 def group(
     iterator: Iterator[T],
     size: Optional[int] = None,
+    *,
     interval: Optional[datetime.timedelta] = None,
     by: Optional[Callable[[T], Any]] = None,
 ) -> Iterator[List[T]]:
@@ -111,6 +113,7 @@ def group(
 def groupby(
     iterator: Iterator[T],
     key: Callable[[T], U],
+    *,
     size: Optional[int] = None,
     interval: Optional[datetime.timedelta] = None,
 ) -> Iterator[Tuple[U, List[T]]]:
@@ -123,6 +126,7 @@ def groupby(
 def map(
     transformation: Callable[[T], U],
     iterator: Iterator[T],
+    *,
     concurrency: int = 1,
     ordered: bool = True,
     via: "Literal['thread', 'process']" = "thread",
@@ -145,6 +149,7 @@ def map(
 def amap(
     transformation: Callable[[T], Coroutine[Any, Any, U]],
     iterator: Iterator[T],
+    *,
     concurrency: int = 1,
     ordered: bool = True,
 ) -> Iterator[U]:
@@ -166,6 +171,7 @@ def observe(iterator: Iterator[T], what: str) -> Iterator[T]:
 def skip(
     iterator: Iterator[T],
     count: Optional[int] = None,
+    *,
     until: Optional[Callable[[T], Any]] = None,
 ) -> Iterator[T]:
     validate_iterator(iterator)
@@ -182,6 +188,7 @@ def skip(
 def throttle(
     iterator: Iterator[T],
     count: Optional[int],
+    *,
     per: Optional[datetime.timedelta] = None,
 ) -> Iterator[T]:
     validate_optional_positive_count(count)
@@ -194,6 +201,7 @@ def throttle(
 def truncate(
     iterator: Iterator[T],
     count: Optional[int] = None,
+    *,
     when: Optional[Callable[[T], Any]] = None,
 ) -> Iterator[T]:
     validate_iterator(iterator)

--- a/streamable/functions.py
+++ b/streamable/functions.py
@@ -54,8 +54,8 @@ U = TypeVar("U")
 
 def catch(
     iterator: Iterator[T],
-    kind: Type[Exception] = Exception,
-    *others: Type[Exception],
+    error_type: Optional[Type[Exception]],
+    *others: Optional[Type[Exception]],
     when: Optional[Callable[[Exception], Any]] = None,
     replacement: T = NO_REPLACEMENT,  # type: ignore
     finally_raise: bool = False,
@@ -63,7 +63,7 @@ def catch(
     validate_iterator(iterator)
     return CatchIterator(
         iterator,
-        (kind, *others),
+        (error_type, *others),
         when,
         replacement,
         finally_raise,

--- a/streamable/functions.py
+++ b/streamable/functions.py
@@ -13,7 +13,6 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    cast,
 )
 
 from streamable.iterators import (
@@ -28,7 +27,6 @@ from streamable.iterators import (
     FlattenIterator,
     GroupbyIterator,
     GroupIterator,
-    IntervalThrottleIterator,
     ObserveIterator,
     OSConcurrentMapIterator,
     PredicateSkipIterator,
@@ -43,8 +41,8 @@ from streamable.util.validationtools import (
     validate_group_size,
     validate_iterator,
     validate_optional_count,
-    validate_throttle_interval,
-    validate_throttle_per_period,
+    validate_optional_positive_count,
+    validate_throttle_per,
 )
 
 with suppress(ImportError):
@@ -183,27 +181,13 @@ def skip(
 
 def throttle(
     iterator: Iterator[T],
-    per_second: int = cast(int, float("inf")),
-    per_minute: int = cast(int, float("inf")),
-    per_hour: int = cast(int, float("inf")),
-    interval: datetime.timedelta = datetime.timedelta(0),
+    count: Optional[int],
+    per: Optional[datetime.timedelta] = None,
 ) -> Iterator[T]:
-    validate_iterator(iterator)
-    validate_throttle_per_period("per_second", per_second)
-    validate_throttle_per_period("per_minute", per_minute)
-    validate_throttle_per_period("per_hour", per_hour)
-    validate_throttle_interval(interval)
-
-    for per_period, period in (
-        (per_second, datetime.timedelta(seconds=1)),
-        (per_minute, datetime.timedelta(minutes=1)),
-        (per_hour, datetime.timedelta(hours=1)),
-    ):
-        if per_period < float("inf"):
-            iterator = YieldsPerPeriodThrottleIterator(iterator, per_period, period)
-
-    if interval > datetime.timedelta(0):
-        iterator = IntervalThrottleIterator(iterator, interval)
+    validate_optional_positive_count(count)
+    validate_throttle_per(per)
+    if count and per:
+        iterator = YieldsPerPeriodThrottleIterator(iterator, count, per)
     return iterator
 
 

--- a/streamable/iterators.py
+++ b/streamable/iterators.py
@@ -61,14 +61,14 @@ class CatchIterator(Iterator[T]):
     def __init__(
         self,
         iterator: Iterator[T],
-        kinds: Tuple[Type[Exception], ...],
+        error_types: Iterable[Optional[Type[Exception]]],
         when: Optional[Callable[[Exception], Any]],
         replacement: T,
         finally_raise: bool,
     ) -> None:
         validate_iterator(iterator)
         self.iterator = iterator
-        self.kinds = kinds
+        self.error_types: Tuple[Type[Exception], ...] = tuple(filter(None, error_types))
         self.when = wrap_error(when, StopIteration) if when else None
         self.replacement = replacement
         self.finally_raise = finally_raise
@@ -84,7 +84,7 @@ class CatchIterator(Iterator[T]):
                     self._to_be_finally_raised = None
                     raise exception
                 raise
-            except self.kinds as exception:
+            except self.error_types as exception:
                 if not self.when or self.when(exception):
                     if self._to_be_finally_raised is None:
                         self._to_be_finally_raised = exception

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -135,17 +135,17 @@ class Stream(Iterable[T]):
 
     def catch(
         self,
-        kind: Type[Exception] = Exception,
-        *others: Type[Exception],
+        error_type: Optional[Type[Exception]],
+        *others: Optional[Type[Exception]],
         when: Optional[Callable[[Exception], Any]] = None,
         replacement: T = NO_REPLACEMENT,  # type: ignore
         finally_raise: bool = False,
     ) -> "Stream[T]":
         """
-        Catches the upstream exceptions if they are instances of `kind` (or `others`) and they satisfy the `when` predicate.
+        Catches the upstream exceptions if they are instances of `error_type` (or `others`) and they satisfy the `when` predicate.
 
         Args:
-            kind (Type[Exception], optional): The type of exceptions to catch. (default: catches `Exception`)
+            error_type (Type[Exception], optional): The type of exceptions to catch.
             *others (Type[Exception], optional): Additional types of exceptions to catch.
             when (Optional[Callable[[Exception], Any]], optional): An additional condition that must be satisfied to catch the exception, i.e. `when(exception)` must be truthy. (default: no additional condition)
             replacement (T, optional): The value to yield when an exception is catched. (default: do not yield any replacement value)
@@ -156,7 +156,7 @@ class Stream(Iterable[T]):
         """
         return CatchStream(
             self,
-            kind,
+            error_type,
             *others,
             when=when,
             replacement=replacement,
@@ -561,14 +561,14 @@ class CatchStream(DownStream[T, T]):
     def __init__(
         self,
         upstream: Stream[T],
-        kind: Type[Exception],
-        *others: Type[Exception],
+        error_type: Optional[Type[Exception]],
+        *others: Optional[Type[Exception]],
         when: Optional[Callable[[Exception], Any]],
         replacement: T,
         finally_raise: bool,
     ) -> None:
         super().__init__(upstream)
-        self._kind = kind
+        self._error_type = error_type
         self._others = others
         self._when = when
         self._replacement = replacement

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -212,12 +212,12 @@ class Stream(Iterable[T]):
         """
         return DistinctStream(self, key, consecutive_only)
 
-    def filter(self, when: Optional[Callable[[T], Any]] = None) -> "Stream[T]":
+    def filter(self, when: Optional[Callable[[T], Any]]) -> "Stream[T]":
         """
         Filters the stream to yield only elements satisfying the `when` predicate.
 
         Args:
-            when (Optional[Callable[[T], Any]], optional): An element is kept when `when(elem)` is truthy. If `when` is None, elements that are truthy themselves are kept. (default: keeps truthy elements)
+            when (Optional[Callable[[T], Any]], optional): An element is kept when `when(elem)` is truthy. If `when` is None, elements that are truthy themselves are kept.
 
         Returns:
             Stream[T]: A stream of upstream elements satisfying the `when` predicate.

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -187,7 +187,10 @@ class Stream(Iterable[T]):
         return self
 
     def distinct(
-        self, key: Optional[Callable[[T], Any]] = None, consecutive_only: bool = False
+        self,
+        key: Optional[Callable[[T], Any]] = None,
+        *,
+        consecutive_only: bool = False,
     ) -> "Stream[T]":
         """
         Filters the stream to yield only distinct elements.
@@ -225,68 +228,75 @@ class Stream(Iterable[T]):
     @overload
     def flatten(
         self: "Stream[Iterable[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[Collection[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[Stream[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[Iterator[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[List[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[Sequence[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[builtins.map[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[builtins.filter[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[Set[U]]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[U]": ...
 
     @overload
     def flatten(
         self: "Stream[range]",
+        *,
         concurrency: int = 1,
     ) -> "Stream[int]": ...
     # fmt: on
 
-    def flatten(
-        self: "Stream[Iterable[U]]",
-        concurrency: int = 1,
-    ) -> "Stream[U]":
+    def flatten(self: "Stream[Iterable[U]]", *, concurrency: int = 1) -> "Stream[U]":
         """
         Iterates over upstream elements assumed to be iterables, and individually yields their items.
 
@@ -301,6 +311,7 @@ class Stream(Iterable[T]):
     def foreach(
         self,
         effect: Callable[[T], Any],
+        *,
         concurrency: int = 1,
         ordered: bool = True,
         via: "Literal['thread', 'process']" = "thread",
@@ -324,6 +335,7 @@ class Stream(Iterable[T]):
     def aforeach(
         self,
         effect: Callable[[T], Coroutine],
+        *,
         concurrency: int = 1,
         ordered: bool = True,
     ) -> "Stream[T]":
@@ -344,6 +356,7 @@ class Stream(Iterable[T]):
     def group(
         self,
         size: Optional[int] = None,
+        *,
         interval: Optional[datetime.timedelta] = None,
         by: Optional[Callable[[T], Any]] = None,
     ) -> "Stream[List[T]]":
@@ -371,6 +384,7 @@ class Stream(Iterable[T]):
     def groupby(
         self,
         key: Callable[[T], U],
+        *,
         size: Optional[int] = None,
         interval: Optional[datetime.timedelta] = None,
     ) -> "Stream[Tuple[U, List[T]]]":
@@ -395,6 +409,7 @@ class Stream(Iterable[T]):
     def map(
         self,
         transformation: Callable[[T], U],
+        *,
         concurrency: int = 1,
         ordered: bool = True,
         via: "Literal['thread', 'process']" = "thread",
@@ -417,6 +432,7 @@ class Stream(Iterable[T]):
     def amap(
         self,
         transformation: Callable[[T], Coroutine[Any, Any, U]],
+        *,
         concurrency: int = 1,
         ordered: bool = True,
     ) -> "Stream[U]":
@@ -472,7 +488,7 @@ class Stream(Iterable[T]):
         return func(self, *args, **kwargs)
 
     def skip(
-        self, count: Optional[int] = None, until: Optional[Callable[[T], Any]] = None
+        self, count: Optional[int] = None, *, until: Optional[Callable[[T], Any]] = None
     ) -> "Stream[T]":
         """
         Skips elements until `until(elem)` is truthy, or `count` elements have been skipped.
@@ -490,6 +506,7 @@ class Stream(Iterable[T]):
 
     def throttle(
         self,
+        *,
         per_second: int = cast(int, float("inf")),
         per_minute: int = cast(int, float("inf")),
         per_hour: int = cast(int, float("inf")),
@@ -520,7 +537,7 @@ class Stream(Iterable[T]):
         return ThrottleStream(self, per_second, per_minute, per_hour, interval)
 
     def truncate(
-        self, count: Optional[int] = None, when: Optional[Callable[[T], Any]] = None
+        self, count: Optional[int] = None, *, when: Optional[Callable[[T], Any]] = None
     ) -> "Stream[T]":
         """
         Stops an iteration as soon as `when(elem)` is truthy, or `count` elements have been yielded.

--- a/streamable/util/validationtools.py
+++ b/streamable/util/validationtools.py
@@ -44,16 +44,21 @@ def validate_count(count: int):
         raise ValueError(f"`count` must be >= 0 but got {count}")
 
 
+def validate_positive_count(count: int):
+    if count < 1:
+        raise ValueError(f"`count` must be >= 1 but got {count}")
+
+
 def validate_optional_count(count: Optional[int]):
     if count is not None:
         validate_count(count)
 
 
-def validate_throttle_per_period(per_period_arg_name: str, value: int) -> None:
-    if value < 1:
-        raise ValueError(f"`{per_period_arg_name}` must be >= 1 but got {value}")
+def validate_optional_positive_count(count: Optional[int]):
+    if count is not None:
+        validate_positive_count(count)
 
 
-def validate_throttle_interval(interval: datetime.timedelta) -> None:
-    if interval < datetime.timedelta(0):
-        raise ValueError(f"`interval` must be >= 0 but got {repr(interval)}")
+def validate_throttle_per(per: Optional[datetime.timedelta]) -> None:
+    if per is not None and per < datetime.timedelta(0):
+        raise ValueError(f"`per` must be >= 0 but got {repr(per)}")

--- a/streamable/visitors/equality.py
+++ b/streamable/visitors/equality.py
@@ -135,10 +135,8 @@ class EqualityVisitor(Visitor[bool]):
         return (
             isinstance(self.other, ThrottleStream)
             and stream.upstream.accept(EqualityVisitor(self.other.upstream))
-            and stream._per_second == self.other._per_second
-            and stream._per_minute == self.other._per_minute
-            and stream._per_hour == self.other._per_hour
-            and stream._interval == self.other._interval
+            and stream._count == self.other._count
+            and stream._per == self.other._per
         )
 
     def visit_truncate_stream(self, stream: TruncateStream[T]) -> bool:

--- a/streamable/visitors/equality.py
+++ b/streamable/visitors/equality.py
@@ -31,8 +31,8 @@ class EqualityVisitor(Visitor[bool]):
         return (
             isinstance(self.other, CatchStream)
             and stream.upstream.accept(EqualityVisitor(self.other.upstream))
-            and set(stream._others).union((stream._kind,))
-            == set(self.other._others).union((self.other._kind,))
+            and set(stream._others).union((stream._error_type,))
+            == set(self.other._others).union((self.other._error_type,))
             and stream._when == self.other._when
             and stream._replacement == self.other._replacement
             and stream._finally_raise == self.other._finally_raise

--- a/streamable/visitors/iterator.py
+++ b/streamable/visitors/iterator.py
@@ -29,7 +29,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
     def visit_catch_stream(self, stream: CatchStream[T]) -> Iterator[T]:
         return functions.catch(
             stream.upstream.accept(self),
-            stream._kind,
+            stream._error_type,
             *stream._others,
             when=stream._when,
             replacement=stream._replacement,

--- a/streamable/visitors/iterator.py
+++ b/streamable/visitors/iterator.py
@@ -40,7 +40,7 @@ class IteratorVisitor(Visitor[Iterator[T]]):
         return functions.distinct(
             stream.upstream.accept(self),
             stream._key,
-            stream._consecutive_only,
+            consecutive_only=stream._consecutive_only,
         )
 
     def visit_filter_stream(self, stream: FilterStream[T]) -> Iterator[T]:
@@ -82,8 +82,8 @@ class IteratorVisitor(Visitor[Iterator[T]]):
             functions.group(
                 stream.upstream.accept(IteratorVisitor[U]()),
                 stream._size,
-                stream._interval,
-                stream._by,
+                interval=stream._interval,
+                by=stream._by,
             ),
         )
 
@@ -93,8 +93,8 @@ class IteratorVisitor(Visitor[Iterator[T]]):
             functions.groupby(
                 stream.upstream.accept(IteratorVisitor[U]()),
                 stream._key,
-                stream._size,
-                stream._interval,
+                size=stream._size,
+                interval=stream._interval,
             ),
         )
 
@@ -125,21 +125,21 @@ class IteratorVisitor(Visitor[Iterator[T]]):
         return functions.skip(
             stream.upstream.accept(self),
             stream._count,
-            stream._until,
+            until=stream._until,
         )
 
     def visit_throttle_stream(self, stream: ThrottleStream[T]) -> Iterator[T]:
         return functions.throttle(
             stream.upstream.accept(self),
             stream._count,
-            stream._per,
+            per=stream._per,
         )
 
     def visit_truncate_stream(self, stream: TruncateStream[T]) -> Iterator[T]:
         return functions.truncate(
             stream.upstream.accept(self),
             stream._count,
-            stream._when,
+            when=stream._when,
         )
 
     def visit_stream(self, stream: Stream[T]) -> Iterator[T]:

--- a/streamable/visitors/iterator.py
+++ b/streamable/visitors/iterator.py
@@ -131,10 +131,8 @@ class IteratorVisitor(Visitor[Iterator[T]]):
     def visit_throttle_stream(self, stream: ThrottleStream[T]) -> Iterator[T]:
         return functions.throttle(
             stream.upstream.accept(self),
-            stream._per_second,
-            stream._per_minute,
-            stream._per_hour,
-            stream._interval,
+            stream._count,
+            stream._per,
         )
 
     def visit_truncate_stream(self, stream: TruncateStream[T]) -> Iterator[T]:

--- a/streamable/visitors/representation.py
+++ b/streamable/visitors/representation.py
@@ -39,14 +39,14 @@ class ToStringVisitor(Visitor[str], ABC):
         if stream._replacement is not NO_REPLACEMENT:
             replacement = f", replacement={self.to_string(stream._replacement)}"
 
-        kinds = ", ".join(
+        error_types = ", ".join(
             map(
                 lambda err: getattr(err, "__name__", self.to_string(err)),
-                (stream._kind, *stream._others),
+                (stream._error_type, *stream._others),
             )
         )
         self.methods_reprs.append(
-            f"catch({kinds}, when={self.to_string(stream._when)}{replacement}, finally_raise={self.to_string(stream._finally_raise)})"
+            f"catch({error_types}, when={self.to_string(stream._when)}{replacement}, finally_raise={self.to_string(stream._finally_raise)})"
         )
         return stream.upstream.accept(self)
 

--- a/streamable/visitors/representation.py
+++ b/streamable/visitors/representation.py
@@ -116,7 +116,7 @@ class ToStringVisitor(Visitor[str], ABC):
 
     def visit_throttle_stream(self, stream: ThrottleStream[T]) -> str:
         self.methods_reprs.append(
-            f"throttle(per_second={self.to_string(stream._per_second)}, per_minute={self.to_string(stream._per_minute)}, per_hour={self.to_string(stream._per_hour)}, interval={self.to_string(stream._interval)})"
+            f"throttle({self.to_string(stream._count)}, per={self.to_string(stream._per)})"
         )
         return stream.upstream.accept(self)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -35,6 +35,8 @@ class TestFunctions(unittest.TestCase):
         catched_it_2: Iterator[int] = catch(iterator, Exception, finally_raise=True)
         observed_it_1: Iterator[int] = observe(iterator, what="objects")
         throttleed_it_1: Iterator[int] = throttle(
-            iterator, per_second=1, interval=datetime.timedelta(seconds=0.1)
+            iterator,
+            1,
+            per=datetime.timedelta(seconds=1),
         )
         truncated_it_1: Iterator[int] = truncate(iterator, count=1)

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -318,7 +318,7 @@ class TestReadme(unittest.TestCase):
                     .flatten()
                     .observe("written pokemons")
                     # Catches exceptions and raises the 1st one at the end of the iteration
-                    .catch(finally_raise=True)
+                    .catch(Exception, finally_raise=True)
                 )
 
                 pipeline()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -172,7 +172,7 @@ class TestStream(unittest.TestCase):
             .flatten()
             .map(identity)
             .amap(async_identity)
-            .filter()
+            .filter(None)
             .foreach(identity)
             .aforeach(async_identity)
             .catch(Exception)
@@ -205,7 +205,7 @@ class TestStream(unittest.TestCase):
             .skip(10)
             .skip(until=lambda _: True)
             .distinct(lambda _: _)
-            .filter()
+            .filter(None)
             .map(lambda i: (i,))
             .map(lambda i: (i,), concurrency=2)
             .filter(star(bool))
@@ -812,11 +812,6 @@ class TestStream(unittest.TestCase):
             list(Stream(src).filter(None)),
             list(filter(None, src)),
             msg="`filter` with None predicate must act like builtin filter with None predicate.",
-        )
-        self.assertListEqual(
-            list(Stream(src).filter()),
-            list(filter(None, src)),
-            msg="`filter` without predicate must act like builtin filter with None predicate.",
         )
 
     def test_skip(self) -> None:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -177,7 +177,7 @@ class TestStream(unittest.TestCase):
             .aforeach(async_identity)
             .catch()
             .observe()
-            .throttle(1)
+            .throttle(per_second=1)
             .source,
             src,
             msg="`source` must be propagated by operations",
@@ -219,7 +219,7 @@ class TestStream(unittest.TestCase):
             .map(star(lambda key, group: group))
             .observe("groups")
             .flatten(concurrency=4)
-            .throttle(64, interval=datetime.timedelta(seconds=1))
+            .throttle(per_second=64, interval=datetime.timedelta(seconds=1))
             .observe("foos")
             .catch(finally_raise=True)
             .catch(TypeError, ValueError, ZeroDivisionError)
@@ -569,13 +569,13 @@ class TestStream(unittest.TestCase):
             catched_exc,
             msg="At any concurrency, `map` and `foreach` and `amap` must raise",
         ):
-            list(method(Stream(src), throw_func(raised_exc), concurrency))  # type: ignore
+            list(method(Stream(src), throw_func(raised_exc), concurrency=concurrency))  # type: ignore
 
         self.assertListEqual(
             list(
-                method(Stream(src), throw_for_odd_func(raised_exc), concurrency).catch(
-                    *catched_exc
-                )
+                method(
+                    Stream(src), throw_for_odd_func(raised_exc), concurrency=concurrency  # type: ignore
+                ).catch(*catched_exc)
             ),
             list(even_src),
             msg="At any concurrency, `map` and `foreach` and `amap` must not stop after one exception occured.",
@@ -1504,7 +1504,7 @@ class TestStream(unittest.TestCase):
     def test_observe(self) -> None:
         value_error_rainsing_stream: Stream[List[int]] = (
             Stream("123--678")
-            .throttle(10)
+            .throttle(per_second=10)
             .observe("chars")
             .map(int)
             .observe("ints")
@@ -1646,7 +1646,7 @@ class TestStream(unittest.TestCase):
             .foreach(identity, concurrency=3)
             .aforeach(async_identity, concurrency=3)
             .group(3, by=bool)
-            .flatten(3)
+            .flatten(concurrency=3)
             .groupby(bool)
             .map(identity, via="process")
             .amap(async_identity)
@@ -1665,7 +1665,7 @@ class TestStream(unittest.TestCase):
             .foreach(identity, concurrency=3)
             .aforeach(async_identity, concurrency=3)
             .group(3, by=bool)
-            .flatten(3)
+            .flatten(concurrency=3)
             .groupby(bool)
             .map(identity, via="process")
             .amap(async_identity)
@@ -1683,7 +1683,7 @@ class TestStream(unittest.TestCase):
             .foreach(identity, concurrency=3)
             .aforeach(async_identity, concurrency=3)
             .group(3, by=bool)
-            .flatten(3)
+            .flatten(concurrency=3)
             .groupby(bool)
             .map(identity, via="process")
             .amap(async_identity)
@@ -1701,7 +1701,7 @@ class TestStream(unittest.TestCase):
             .foreach(identity, concurrency=3)
             .aforeach(async_identity, concurrency=3)
             .group(3, by=bool)
-            .flatten(3)
+            .flatten(concurrency=3)
             .groupby(bool)
             .map(identity, via="process")
             .amap(async_identity)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -175,7 +175,7 @@ class TestStream(unittest.TestCase):
             .filter()
             .foreach(identity)
             .aforeach(async_identity)
-            .catch()
+            .catch(Exception)
             .observe()
             .throttle(1, per=datetime.timedelta(seconds=1))
             .source,
@@ -224,7 +224,7 @@ class TestStream(unittest.TestCase):
                 per=datetime.timedelta(seconds=1),
             )
             .observe("foos")
-            .catch(finally_raise=True)
+            .catch(Exception, finally_raise=True)
             .catch(TypeError, ValueError, ZeroDivisionError)
             .catch(TypeError, replacement=None, finally_raise=True)
         )
@@ -1321,7 +1321,7 @@ class TestStream(unittest.TestCase):
 
     def test_catch(self) -> None:
         self.assertListEqual(
-            list(Stream(src).catch(finally_raise=True)),
+            list(Stream(src).catch(Exception, finally_raise=True)),
             list(src),
             msg="`catch` should yield elements in exception-less scenarios",
         )
@@ -1332,7 +1332,7 @@ class TestStream(unittest.TestCase):
         ):
             from streamable.functions import catch
 
-            catch(cast(Iterator[int], [3, 4]))
+            catch(cast(Iterator[int], [3, 4]), Exception)
 
         def f(i):
             return i / (3 - i)
@@ -1343,10 +1343,10 @@ class TestStream(unittest.TestCase):
         self.assertListEqual(
             list(stream.catch(ZeroDivisionError)),
             list(map(f, safe_src)),
-            msg="If the exception type matches the `kind`, then the impacted element should be ignored.",
+            msg="If the exception type matches the `error_type`, then the impacted element should be ignored.",
         )
         self.assertListEqual(
-            list(stream.catch()),
+            list(stream.catch(Exception)),
             list(map(f, safe_src)),
             msg="If the predicate is not specified, then all exceptions should be catched.",
         )
@@ -1372,7 +1372,7 @@ class TestStream(unittest.TestCase):
 
         erroring_stream: Stream[int] = Stream(lambda: map(lambda f: f(), functions))
         for catched_erroring_stream in [
-            erroring_stream.catch(finally_raise=True),
+            erroring_stream.catch(Exception, finally_raise=True),
             erroring_stream.catch(Exception, finally_raise=True),
         ]:
             erroring_stream_iterator = iter(catched_erroring_stream)

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -57,7 +57,7 @@ class TestVisitor(unittest.TestCase):
             return stream.accept(DepthVisitor())
 
         self.assertEqual(
-            depth(Stream(range(10)).map(str).filter()),
+            depth(Stream(range(10)).map(str).foreach(print)),
             3,
             msg="DepthVisitor example should work",
         )

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 # to show the CHANGELOG: git log -- version.py
-__version__ = "1.4.8"
+__version__ = "1.5.0-rc"


### PR DESCRIPTION
Minor version increase, time for breaking changes:
- [x] add kw-only args constraints
- [x] `.throttle`: more flexible params
- [x] `.catch`: mandatory nullable first arg
- [x] uniformize the signatures of `functions` and `Stream`'s methods
- [x] `.filter`: mandatory nullable first arg

**Note: old client code may break and require little rewriting, but no operation will silently change its behavior 👍🏻**