### PR TITLE
preserve `.filter`/`.catch`/`.throttle` backward compatibility

### DIFF
--- a/streamable/functions.py
+++ b/streamable/functions.py
@@ -39,7 +39,7 @@ from streamable.util.validationtools import (
     validate_concurrency,
     validate_group_size,
     validate_iterator,
-    validate_not_none,
+    # validate_not_none,
     validate_optional_count,
     validate_optional_positive_count,
     validate_optional_positive_interval,
@@ -62,7 +62,7 @@ def catch(
     finally_raise: bool = False,
 ) -> Iterator[T]:
     validate_iterator(iterator)
-    validate_not_none(finally_raise, "finally_raise")
+    # validate_not_none(finally_raise, "finally_raise")
     return CatchIterator(
         iterator,
         (error_type, *others),
@@ -79,7 +79,7 @@ def distinct(
     consecutive_only: bool = False,
 ) -> Iterator[T]:
     validate_iterator(iterator)
-    validate_not_none(consecutive_only, "consecutive_only")
+    # validate_not_none(consecutive_only, "consecutive_only")
     if consecutive_only:
         return ConsecutiveDistinctIterator(iterator, key)
     return DistinctIterator(iterator, key)
@@ -135,8 +135,8 @@ def map(
     via: "Literal['thread', 'process']" = "thread",
 ) -> Iterator[U]:
     validate_iterator(iterator)
-    validate_not_none(transformation, "transformation")
-    validate_not_none(ordered, "ordered")
+    # validate_not_none(transformation, "transformation")
+    # validate_not_none(ordered, "ordered")
     validate_concurrency(concurrency)
     validate_via(via)
     if concurrency == 1:
@@ -160,8 +160,8 @@ def amap(
     ordered: bool = True,
 ) -> Iterator[U]:
     validate_iterator(iterator)
-    validate_not_none(transformation, "transformation")
-    validate_not_none(ordered, "ordered")
+    # validate_not_none(transformation, "transformation")
+    # validate_not_none(ordered, "ordered")
     validate_concurrency(concurrency)
     return AsyncConcurrentMapIterator(
         iterator,
@@ -173,7 +173,7 @@ def amap(
 
 def observe(iterator: Iterator[T], what: str) -> Iterator[T]:
     validate_iterator(iterator)
-    validate_not_none(what, "what")
+    # validate_not_none(what, "what")
     return ObserveIterator(iterator, what)
 
 

--- a/streamable/functions.py
+++ b/streamable/functions.py
@@ -55,7 +55,7 @@ U = TypeVar("U")
 
 def catch(
     iterator: Iterator[T],
-    error_type: Optional[Type[Exception]],
+    error_type: Optional[Type[Exception]] = Exception,
     *others: Optional[Type[Exception]],
     when: Optional[Callable[[Exception], Any]] = None,
     replacement: T = NO_REPLACEMENT,  # type: ignore

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -138,7 +138,7 @@ class Stream(Iterable[T]):
 
     def catch(
         self,
-        error_type: Optional[Type[Exception]],
+        error_type: Optional[Type[Exception]] = Exception,
         *others: Optional[Type[Exception]],
         when: Optional[Callable[[Exception], Any]] = None,
         replacement: T = NO_REPLACEMENT,  # type: ignore
@@ -148,7 +148,7 @@ class Stream(Iterable[T]):
         Catches the upstream exceptions if they are instances of `error_type` (or `others`) and they satisfy the `when` predicate.
 
         Args:
-            error_type (Type[Exception]): The exception type to catch.
+            error_type (Type[Exception], optional): The exception type to catch. (default: catch all `Exception`s)
             *others (Type[Exception], optional): Additional exception types to catch.
             when (Optional[Callable[[Exception], Any]], optional): An additional condition that must be satisfied to catch the exception, i.e. `when(exception)` must be truthy. (default: no additional condition)
             replacement (T, optional): The value to yield when an exception is catched. (default: do not yield any replacement value)

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -218,18 +218,19 @@ class Stream(Iterable[T]):
         validate_not_none(consecutive_only, "consecutive_only")
         return DistinctStream(self, key, consecutive_only)
 
-    def filter(self, when: Callable[[T], Any]) -> "Stream[T]":
+    def filter(self, when: Callable[[T], Any] = bool) -> "Stream[T]":
         """
         Filters the stream to yield only elements satisfying the `when` predicate.
 
         Args:
-            when (Callable[[T], Any]): An element is kept if `when(elem)` is truthy. Set `when=bool` to keep elements that are truthy themselves.
+            when (Callable[[T], Any], optional): An element is kept if `when(elem)` is truthy. (default: keeps truthy elements)
 
         Returns:
             Stream[T]: A stream of upstream elements satisfying the `when` predicate.
         """
-        validate_not_none(when, "when")
-        return FilterStream(self, when)
+        # Unofficially accept `stream.filter(None)`, behaving as builtin `filter(None, iter)`
+        # validate_not_none(when, "when")
+        return FilterStream(self, cast(Optional[Callable[[T], Any]], when) or bool)
 
     # fmt: off
     @overload

--- a/streamable/stream.py
+++ b/streamable/stream.py
@@ -27,7 +27,7 @@ from streamable.util.loggertools import get_logger
 from streamable.util.validationtools import (
     validate_concurrency,
     validate_group_size,
-    validate_not_none,
+    # validate_not_none,
     validate_optional_count,
     validate_optional_positive_count,
     validate_optional_positive_interval,
@@ -66,7 +66,7 @@ class Stream(Iterable[T]):
         Args:
             source (Union[Iterable[T], Callable[[], Iterable[T]]]): The iterable to decorate. Can be specified via a function that will be called each time an iteration is started over the stream.
         """
-        validate_not_none(source, "source")
+        # validate_not_none(source, "source")
         self._source = source
         self._upstream: "Optional[Stream]" = None
 
@@ -90,7 +90,7 @@ class Stream(Iterable[T]):
         """
         `a + b` returns a stream yielding all elements of `a`, followed by all elements of `b`.
         """
-        validate_not_none(other, "other")
+        # validate_not_none(other, "other")
         return cast(Stream[T], Stream((self, other)).flatten())
 
     def __iter__(self) -> Iterator[T]:
@@ -133,7 +133,7 @@ class Stream(Iterable[T]):
         """
         Entry point to visit this stream (en.wikipedia.org/wiki/Visitor_pattern).
         """
-        validate_not_none(visitor, "visitor")
+        # validate_not_none(visitor, "visitor")
         return visitor.visit_stream(self)
 
     def catch(
@@ -157,7 +157,7 @@ class Stream(Iterable[T]):
         Returns:
             Stream[T]: A stream of upstream elements catching the eligible exceptions.
         """
-        validate_not_none(finally_raise, "finally_raise")
+        # validate_not_none(finally_raise, "finally_raise")
         return CatchStream(
             self,
             error_type,
@@ -187,7 +187,7 @@ class Stream(Iterable[T]):
         Returns:
             Stream[T]: This stream.
         """
-        validate_not_none(level, "level")
+        # validate_not_none(level, "level")
         get_logger().log(level, str(self))
         return self
 
@@ -215,7 +215,7 @@ class Stream(Iterable[T]):
         Returns:
             Stream: A stream containing only unique upstream elements.
         """
-        validate_not_none(consecutive_only, "consecutive_only")
+        # validate_not_none(consecutive_only, "consecutive_only")
         return DistinctStream(self, key, consecutive_only)
 
     def filter(self, when: Callable[[T], Any] = bool) -> "Stream[T]":
@@ -336,8 +336,8 @@ class Stream(Iterable[T]):
         Returns:
             Stream[T]: A stream of upstream elements, unchanged.
         """
-        validate_not_none(effect, "effect")
-        validate_not_none(ordered, "ordered")
+        # validate_not_none(effect, "effect")
+        # validate_not_none(ordered, "ordered")
         validate_concurrency(concurrency)
         validate_via(via)
         return ForeachStream(self, effect, concurrency, ordered, via)
@@ -360,8 +360,8 @@ class Stream(Iterable[T]):
         Returns:
             Stream[T]: A stream of upstream elements, unchanged.
         """
-        validate_not_none(effect, "effect")
-        validate_not_none(ordered, "ordered")
+        # validate_not_none(effect, "effect")
+        # validate_not_none(ordered, "ordered")
         validate_concurrency(concurrency)
         return AForeachStream(self, effect, concurrency, ordered)
 
@@ -416,7 +416,7 @@ class Stream(Iterable[T]):
         Returns:
             Stream[Tuple[U, List[T]]]: A stream of upstream elements grouped by key, as `(key, elements)` tuples.
         """
-        validate_not_none(key, "key")
+        # validate_not_none(key, "key")
         return GroupbyStream(self, key, size, interval)
 
     def map(
@@ -438,8 +438,8 @@ class Stream(Iterable[T]):
         Returns:
             Stream[R]: A stream of transformed elements.
         """
-        validate_not_none(transformation, "transformation")
-        validate_not_none(ordered, "ordered")
+        # validate_not_none(transformation, "transformation")
+        # validate_not_none(ordered, "ordered")
         validate_concurrency(concurrency)
         validate_via(via)
         return MapStream(self, transformation, concurrency, ordered, via)
@@ -461,8 +461,8 @@ class Stream(Iterable[T]):
         Returns:
             Stream[R]: A stream of transformed elements.
         """
-        validate_not_none(transformation, "transformation")
-        validate_not_none(ordered, "ordered")
+        # validate_not_none(transformation, "transformation")
+        # validate_not_none(ordered, "ordered")
         validate_concurrency(concurrency)
         return AMapStream(self, transformation, concurrency, ordered)
 
@@ -483,7 +483,7 @@ class Stream(Iterable[T]):
         Returns:
             Stream[T]: A stream of upstream elements whose iteration's progress is logged.
         """
-        validate_not_none(what, "what")
+        # validate_not_none(what, "what")
         return ObserveStream(self, what)
 
     def pipe(
@@ -503,7 +503,7 @@ class Stream(Iterable[T]):
         Returns:
             U: Result of `func(self, *args, **kwargs)`.
         """
-        validate_not_none(func, "func")
+        # validate_not_none(func, "func")
         return func(self, *args, **kwargs)
 
     def skip(

--- a/streamable/util/validationtools.py
+++ b/streamable/util/validationtools.py
@@ -67,6 +67,6 @@ def validate_optional_positive_count(count: Optional[int]):
         validate_positive_count(count)
 
 
-def validate_not_none(value: Any, name: str) -> None:
-    if value is None:
-        raise TypeError(f"`{name}` cannot be None")
+# def validate_not_none(value: Any, name: str) -> None:
+#     if value is None:
+#         raise TypeError(f"`{name}` cannot be None")

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -815,12 +815,24 @@ class TestStream(unittest.TestCase):
             list(filter(None, src)),
             msg="`filter` with `bool` as predicate must act like builtin filter with None predicate.",
         )
-        with self.assertRaisesRegex(
-            TypeError,
-            "`when` cannot be None",
-            msg="`filter` does not accept a None predicate",
-        ):
-            list(Stream(src).filter(None))  # type: ignore
+        self.assertListEqual(
+            list(Stream(src).filter()),
+            list(filter(None, src)),
+            msg="`filter` without predicate must act like builtin filter with None predicate.",
+        )
+        self.assertListEqual(
+            list(Stream(src).filter(None)),  # type: ignore
+            list(filter(None, src)),
+            msg="`filter` with None predicate must act unofficially like builtin filter with None predicate.",
+        )
+
+        # Unofficially accept `stream.filter(None)`, behaving as builtin `filter(None, iter)`
+        # with self.assertRaisesRegex(
+        #     TypeError,
+        #     "`when` cannot be None",
+        #     msg="`filter` does not accept a None predicate",
+        # ):
+        #     list(Stream(src).filter(None))  # type: ignore
 
     def test_skip(self) -> None:
         with self.assertRaisesRegex(

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1510,12 +1510,17 @@ class TestStream(unittest.TestCase):
             msg="`catch` should accept multiple types",
         )
 
-        with self.assertRaises(
-            TypeError,
-            msg="`catch` without any error type must raise",
-        ):
-            Stream(src).catch()  # type: ignore
+        # with self.assertRaises(
+        #     TypeError,
+        #     msg="`catch` without any error type must raise",
+        # ):
+        #     Stream(src).catch()  # type: ignore
 
+        self.assertEqual(
+            list(Stream(map(int, "foo")).catch(replacement=0)),
+            [0] * len("foo"),
+            msg="`catch` must catch all errors when no error type provided",
+        )
         self.assertEqual(
             list(
                 Stream(map(int, "foo")).catch(


### PR DESCRIPTION
✅ passing v1.4.8/`tests/test_stream.py`